### PR TITLE
Added power support for the travis.yml file with ppc64le and exclded the jobd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch:
+ - amd64
+ - ppc64le
 go:
   - 1.3.3
   - 1.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,10 @@ go:
   - 1.3.3
   - 1.4
   - tip
+# Disable GO version 1.3 &1.4
+jobs:
+  exclude:
+    - arch: ppc64le
+      go: 1.3.3
+    - arch: ppc64le
+      go: 1.4


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing

jobs excluded go:1.3, 1.4 
exclude:
    - arch: ppc64le
      go: 1.3.3
    - arch: ppc64le
      go: 1.4