### PR TITLE
Wait on xz to avoid leaving zombie processes

### DIFF
--- a/xz_test.go
+++ b/xz_test.go
@@ -48,6 +48,30 @@ func TestDecompress(T *testing.T) {
 	}
 }
 
+func TestEarlyClose(T *testing.T) {
+	source, err := os.Open("testdata/spec.xz")
+	if err != nil {
+		T.Fatal(err)
+	}
+	defer source.Close()
+
+	r, err := NewReader(source)
+	if err != nil {
+		T.Fatal(err)
+	}
+
+	buf := make([]byte, 10)
+	n, err := r.Read(buf)
+	if n != len(buf) {
+		T.Fail()
+	}
+
+	err = r.Close()
+	if err != nil {
+		T.Fail()
+	}
+}
+
 func BenchmarkDecompress(b *testing.B) {
 	data, err := ioutil.ReadFile("testdata/spec.xz")
 	if err != nil {


### PR DESCRIPTION
When Start() is called, Wait() also needs to be called eventually to avoid leaving behind zombie processes, as outlined in cmd.Start's docs:

https://pkg.go.dev/os/exec#Cmd.Start
> After a successful call to Start the Wait method must be called in order to release associated system resources.

This can be observed in practice by adding a `for {}` loop to the end of TestDecompress, then running `ps -A` in an adjacent terminal; you can then see the leftover `xz <defunct>` processes that haven't been waited on.

Additionally, this adds a new test, TestEarlyClose, to ensure that an error isn't returned when xz's stdout is closed early.

(Note that I'm not sure if this works on Windows, or if that's even a supported target for this package. *From a glance at xz's source*, it seemingly should just return exit status 0 when closed early, since SIGPIPE doesn't really exist there, so TestEarlyClose should still pass.)